### PR TITLE
Documentación - Correo Uvigo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ next-env.d.ts
 
 # todos
 TODO.txt
+
+# bun (windows, modifica el archivo bun.lockb)
+bun.lockb

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,3 @@ next-env.d.ts
 
 # todos
 TODO.txt
-
-# bun (windows, modifica el archivo bun.lockb)
-bun.lockb

--- a/src/app/docs/anadir-correo-uvigo/page.mdx
+++ b/src/app/docs/anadir-correo-uvigo/page.mdx
@@ -36,10 +36,10 @@ los principales proveedores: (Gmail y Apple Mail)*
     <Callout variant="error">
         <CalloutDescription>
             Si después del punto anterior (5) te sale una ventana
-    que diga "**El certificado no es válido**", deberás seleccionar
-    **Ajustes avanzados** y a continuación saldrá la información de tu
-    certificado. Baja y selecciona "**Continuar de Todas Formas**" 
-    *En caso de no funcionar, repite la operación. :)*
+            que diga "**El certificado no es válido**", deberás seleccionar
+            **Ajustes avanzados** y a continuación saldrá la información de tu
+            certificado. Baja y selecciona "**Continuar de Todas Formas**" 
+            *En caso de no funcionar, repite la operación. :)*
         </CalloutDescription>
     </Callout>
 6.  Ahora **configura las opciones** a tu gusto junto con el nombre que

--- a/src/app/docs/anadir-correo-uvigo/page.mdx
+++ b/src/app/docs/anadir-correo-uvigo/page.mdx
@@ -1,0 +1,86 @@
+import { Callout, CalloutDescription } from "@/components/ui/callout";
+
+# Añadir el correo de la UVigo a clientes de email
+
+Un aspecto importante es estar al tanto de todas las **notificaciones de la
+universidad**. Al lugar donde estas suelen llegar es al
+[correo de la UVigo](https://correoweb.uvigo.gal/login.php).
+Por eso, es recomendable añadirlo tanto a nuestro ordenador como al móvil.
+Sabemos que la interfaz actual del [correoweb](https://correoweb.uvigo.gal/login.php)
+es un poco pocha. 😅 Pero... ¡No importa! ¡Nosotros te cubrimos la espalda!
+**Existe una manera de recibir todos los mensajes** que lleguen a tu correo
+institucional **en tu servicio favorito** como *Gmail, Apple Mail, Thunderbird
+o Windows Mail*.
+
+*Aquí tendrás algunos ejemplos de como hacerlo en tu dispositivo móvil con
+los principales proveedores: (Gmail y Apple Mail)*
+
+## En móvil:
+
+### Gmail (Android)
+
+1.  Abre la aplicación móvil **Gmail** y dirígete a tu icono de usuario y
+    después selecciona **Añadir otra cuenta** **Otro servicio**
+2.  Introduce tu cuenta de **correo de la UVigo** y dale a siguiente:
+3.  A continuación selecciona **Personal (IMAP)** ✨*Recomendado.*
+4.  Ahora introduce la **Contraseña** de tu correo institucional y presiona
+    **Siguiente**:
+5.  Asegúrate que los **datos** son **correctos** y presiona **Siguiente**
+
+    **Nombre de usuario:** harry.potter@alumnos.uvigo.es *(Correo de la Uvigo)*
+
+    **Contraseña:** Contraseña del correo
+
+    **Servidor:** alumnos.uvigo.es *(El dominio de la cuenta)*
+
+    <Callout variant="error">
+        <CalloutDescription>
+            Si después del punto anterior (5) te sale una ventana
+    que diga "**El certificado no es válido**", deberás seleccionar
+    **Ajustes avanzados** y a continuación saldrá la información de tu
+    certificado. Baja y selecciona "**Continuar de Todas Formas**" 
+    *En caso de no funcionar, repite la operación. :)*
+        </CalloutDescription>
+    </Callout>
+6.  Ahora **configura las opciones** a tu gusto junto con el nombre que
+    aparecerá en tu móvil asociado a la cuenta; presiona siguiente y ¡Listo!
+
+<Callout variant="success">
+    <CalloutDescription>
+        🌟 **¡Ahora ya tienes el correo de la uni en tu móvil!** 😉
+    </CalloutDescription>
+</Callout>
+
+### Apple Mail (IOS)
+
+1.  Ve a **Ajustes** > **Mail** > **Cuentas**.
+2.  Dale click **Añadir cuenta** > **Otra** > **Añadir cuenta de correo**.
+3.  Introduce tu nombre, dirección de correo electrónico de la uvigo y la
+    contraseña y dale a Siguiente.
+4.  Asegúrate de estar en la pestaña **IMAP** ✨ *(Recomendado)* y de que el resto
+    de datos sean correctos:
+
+    **Email:** Correo Uvigo
+
+    **Descripción:** Lo que quieras 😅
+
+    **Servidor:** alumnos.uvigo.es
+
+    **Nombre de Usuario:** nombre.apellido *(login del correo)*
+
+5. Dale a **Guardar**.
+
+<Callout variant="success">
+    <CalloutDescription>
+        🌟 **¡Ahora ya tienes el correo de la uni en tu móvil!** 😉
+    </CalloutDescription>
+</Callout>
+
+
+<Callout variant="info">
+    <CalloutDescription>
+        **IMAP POP~POP3:**
+        Si eres curioso y no entiendes por qué recomendamos el uso del protocolo
+        IMAP, [*ojea aquí las diferencias.*](https://ticket.cdmon.com/es/faq/view/761/diferencia-entre-imap-y-pop3#:~:text=La%20diferencia%20principal%20entre%20estos,y%20almacena%20de%20forma%20local.&text=Este%20protocolo%20trabaja%20directamente%20sobre,muestra%20el%20contenido%20que%20hay)
+    </CalloutDescription>
+</Callout>

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -17,6 +17,9 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         ol: ({ children }) => (
             <ol className="ml-8 list-outside list-decimal">{children}</ol>
         ),
+        a: ({ children }) => (
+            <a className="text-blue-500 hover:underline ">{children}</a>
+        ),
         p: ({ children }) => <p className="my-1 text-base">{children}</p>,
         ...components,
     };

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -17,8 +17,8 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         ol: ({ children }) => (
             <ol className="ml-8 list-outside list-decimal">{children}</ol>
         ),
-        a: ({ children }) => (
-            <a className="text-blue-500 hover:underline ">{children}</a>
+        a: ({ href, children }) => (
+            <a href={href} className="text-blue-500 hover:underline">{children}</a>
         ),
         p: ({ children }) => <p className="my-1 text-base">{children}</p>,
         ...components,


### PR DESCRIPTION
> [!NOTE]  
>  - Me olvidé de crear una rama para esta edición la verdad, en las siguientes la haré. 🫠
>  - Pensé eliminar los emotes y hacer la docu más seria como la pagina de la wifi, pero me parece que queda demasiado "aburrido"
## Añadida la página del Correo de la Uvigo
Información y texto reutilizado de la página de documentación del anterior repositorio de la web.
- Corrección de algunos errores del texto.
- Utilizado el componente callout.

## Añadido el componente de link en mdx-components.tsx
Estilado de los links en el archivo mdx-components.tsx (Color azul y subrayado durante el hover) para poder ser diferenciado en los textos.

## Preview:
![image](https://github.com/axelrogg/daiweb/assets/103317717/408ecb38-5ab6-42cd-b731-78cd946b3316)
![image](https://github.com/axelrogg/daiweb/assets/103317717/8383c5ef-8633-4e83-81a7-70ee8ea5761e)

> [!NOTE]  
> **Ideas**
>  - **De manera general para todas las docus:**
>  - - Me gustaría en un futuro añadir imágenes.
>  - - Modificar la anchura máxima en ordenadores, para que el texto no se extienda por toda la pantalla y esto incluye tambien los cuadros de los callouts...
>  - **En esta docu:**
>  - - Que la parte de para android y apple sean desplegables de alguna manera, para que la gente solo tenga q ver lo q necesita... 

